### PR TITLE
ZRAM Optimizations for Odroid XU4/HC1/HC2

### DIFF
--- a/armbian-install-continue.sh
+++ b/armbian-install-continue.sh
@@ -146,9 +146,6 @@ crontab /home/pinodexmr/PiNode-XMR/var/spool/cron/crontabs/pinodexmr
 echo -e "\e[32mSuccess\e[0m"
 sleep 3
 
-##Set Swappiness lower
-sudo sysctl vm.swappiness=10
-
 ## Remove left over files from git clone actions
 echo -e "\e[32mCleanup leftover directories\e[0m"
 sleep 3

--- a/armbian-installer.sh
+++ b/armbian-installer.sh
@@ -38,6 +38,16 @@ echo 'net.ipv6.conf.all.disable_ipv6 = 1' | sudo tee -a /etc/sysctl.conf
 echo 'net.ipv6.conf.default.disable_ipv6 = 1' | sudo tee -a /etc/sysctl.conf
 echo 'net.ipv6.conf.lo.disable_ipv6 = 1' | sudo tee -a /etc/sysctl.conf
 
+##ZRAM Optimizations to improve system responsiveness and performance
+# I don't tiptoe around the crypto they said I smoking endo
+# it's a gaffe but I got the last laugh despite all the 
+# wining and dining for us to be dining - ChiefGyk3D
+echo "vm.vfs_cache_pressure=500" | sudo tee -a /etc/sysctl.conf
+echo "vm.dirty_background_ratio=1" | sudo tee -a /etc/sysctl.conf
+echo "vm.dirty_ratio=50" | sudo tee -a /etc/sysctl.conf
+# Lock and load the settings
+sudo sysctl -p
+
 #Download stage 2 Install script
 echo -e "\e[32mDownloading stage 2 Installer script\e[0m"
 sleep 3


### PR DESCRIPTION
Made tweaks and tested them with Monero being built. Peaked at 1.85GB RAM used of 2GB with 120MB in swap but system was responsive and Monero compilation in 3 hours from forced update. CPU Seemed to be only maxing one core at a time may look into seeing if we can speed build time up just a bit more in other ways see Issue #16 for discussion and reasoning