### PR TITLE
Fix log.io ExecStart

### DIFF
--- a/etc/systemd/system/log-io-file.service
+++ b/etc/systemd/system/log-io-file.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User=pinodexmr
 Group=pinodexmr
-ExecStart=/usr/local/bin/log.io-file-input
+ExecStart=/usr/bin/log.io-file-input
 Restart=always
 
 [Install]

--- a/etc/systemd/system/log-io-server.service
+++ b/etc/systemd/system/log-io-server.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User=pinodexmr
 Group=pinodexmr
-ExecStart=/usr/local/bin/log.io-server
+ExecStart=/usr/bin/log.io-server
 Restart=always
 
 [Install]


### PR DESCRIPTION
log.io executable locations were incorrect on Ubuntu 22 (Attempted to start from /usr/local/bin while /usr/bin/ is the correct location)